### PR TITLE
Fixed semantic_version ModuleNotFoundError by bumping and fixing the version number; Fixed getpy3 on macos

### DIFF
--- a/bin/getpy3
+++ b/bin/getpy3
@@ -88,7 +88,7 @@ install_python() {
 			eprint "Please install brew and retry."
 			exit 1
 		else
-			brew updte || true
+			brew update || true
 		fi
 
 		# try to fix /usr/local/bin/python on macOS unless stated otherwize

--- a/paella/requirements.txt
+++ b/paella/requirements.txt
@@ -1,4 +1,4 @@
-jinja2
-semantic_version
-six
-click
+jinja2==2.11.2
+semantic_version==2.8.5
+six==1.15.0
+click==7.1.2


### PR DESCRIPTION
Following the error https://app.circleci.com/pipelines/github/RedisTimeSeries/RedisTimeSeries/2196/workflows/ffc40f56-9d3a-4c59-b1de-142d6a5d401c/jobs/5651
and by reading through https://github.com/hpparvi/ldtk/issues/17 we can see that this issue is solved on the latest sematic_version versions...

Confirmed that after bumping and fixing the version number the error evades:
```
Distillers-Mac:paella distiller$ python3 -m pip install -r requirements.txt 
Collecting click==7.1.2
  Using cached click-7.1.2-py2.py3-none-any.whl (82 kB)
Collecting jinja2==2.11.2
  Using cached Jinja2-2.11.2-py2.py3-none-any.whl (125 kB)
Collecting semantic_version==2.8.5
  Using cached semantic_version-2.8.5-py2.py3-none-any.whl (15 kB)
Collecting six==1.15.0
  Using cached six-1.15.0-py2.py3-none-any.whl (10 kB)
Collecting MarkupSafe>=0.23
  Downloading MarkupSafe-1.1.1.tar.gz (19 kB)
Building wheels for collected packages: MarkupSafe
  Building wheel for MarkupSafe (setup.py) ... done
  Created wheel for MarkupSafe: filename=MarkupSafe-1.1.1-cp39-cp39-macosx_10_15_x86_64.whl size=16391 sha256=8486608702c7096e5df94856cfdff7f87105643a8cd3545cc6e9ea4ba7040a34
  Stored in directory: /Users/distiller/Library/Caches/pip/wheels/e0/19/6f/6ba857621f50dc08e084312746ed3ebc14211ba30037d5e44e
Successfully built MarkupSafe
Installing collected packages: MarkupSafe, six, semantic-version, jinja2, click
Successfully installed MarkupSafe-1.1.1 click-7.1.2 jinja2-2.11.2 semantic-version-2.8.5 six-1.15.0
WARNING: You are using pip version 20.3.1; however, version 20.3.3 is available.
You should consider upgrading via the '/usr/local/opt/python@3.9/bin/python3.9 -m pip install --upgrade pip' command.
Distillers-Mac:paella distiller$ cd ..
Distillers-Mac:readies distiller$ ls
LICENSE		README.md	bin		cetara		mk		paella		shibumi
Distillers-Mac:readies distiller$ cd ..
Distillers-Mac:deps distiller$ ls
RedisModulesSDK	readies
Distillers-Mac:deps distiller$ cd ..
Distillers-Mac:project distiller$ ls
Dockerfile	LICENSE		README.md	codecov.yml	docs		ramp.yml	system-setup.py	tools
Dockerfile.arm	Makefile	build		deps		mkdocs.yml	src		tests
Distillers-Mac:project distiller$ BREW_NO_UPDATE=1 python3 ./deps/readies/bin/getredis -v 6 --force
brew list curl &>/dev/null || brew install curl
brew list wget &>/dev/null || brew install wget
brew list git &>/dev/null || brew install git
/usr/local/bin/python3  -m pip --version
/usr/local/bin/python3  -m pip install --disable-pip-version-check --user wheel
/usr/local/bin/python3  -m pip install --disable-pip-version-check --user setuptools --upgrade
# work dir: /var/folders/pt/0xykrh9j62g34sc7znh47kbc0000gn/T/redis.xc3s7o7n
/Users/distiller/project/./deps/readies/bin/getredis:97: DeprecationWarning: Partial versions will be removed in 3.0; use SimpleSpec('1.x.x') instead.
  sv = Version(self.version, partial=True)
wget -O /var/folders/pt/0xykrh9j62g34sc7znh47kbc0000gn/T/redis.xc3s7o7n/redis-6.0.9.tgz https://github.com/redis/redis/archive/6.0.9.tar.gz
tar -C /var/folders/pt/0xykrh9j62g34sc7znh47kbc0000gn/T/redis.xc3s7o7n -xzf /var/folders/pt/0xykrh9j62g34sc7znh47kbc0000gn/T/redis.xc3s7o7n/redis-6.0.9.tgz
make -j `/Users/distiller/project/deps/readies/bin/nproc` BUILD_TLS=yes
make install BUILD_TLS=yes
/usr/local/bin/redis-server --version
Distillers-Mac:project distiller$ vi deps/readies/paella/requirements.txt 
```