### PR TITLE
fixing dead links in the top-level README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 [bin](docs/bin.md): Utilities
 
-[Cetara](docs/cetara.md): C/C++ tools
+[Cetara](cetara/README.md): C/C++ tools
 
-[Paella](docs/paella.md): Python automation library
+[Paella](paella/README.md): Python automation library
 
-[Shibumi](docs/shibumi.md): Bash tools
+[Shibumi](shibumi/README.md): Bash tools
 
-[mk](docs/mk.md): GNU Make-based build framework
-
+[mk](mk/README.md): GNU Make-based build framework


### PR DESCRIPTION
The top-level README contains several dead links. This PR updates each link to point to the existing (though currently empty) READMEs, already present within the respotiroy.