### PR TITLE
added arch? check including manjaro call

### DIFF
--- a/bin/platform
+++ b/bin/platform
@@ -21,6 +21,7 @@ parser.add_argument('--arch', action="store_true", help='CPU Architecture')
 
 parser.add_argument('--debian?', action="store_true", help='is Debian-like distribution?')
 parser.add_argument('--redhat?', action="store_true", help='is Redhat-like distribution?')
+parser.add_argument('--arch?', action="store_true", help='is Arch-like distribution?')
 parser.add_argument('--container?', action="store_true", help='running in container?')
 parser.add_argument('--conda?', action="store_true", help='Has Conda installer?') # TODO
 
@@ -49,6 +50,10 @@ if args.__dict__['redhat?']:
 
 if args.__dict__['container?']:
     print(1 if platform.is_container() else 0)
+    sys.exit(0)
+
+if args.__dict__['arch?']:
+    print(1 if platform.is_arch_compat() else 0)
     sys.exit(0)
 
 ret = ""

--- a/paella/platform.py
+++ b/paella/platform.py
@@ -202,7 +202,7 @@ class Platform:
             self.dist = self._identify_linux_dist(os_release)
             self.os_full_ver = self._identify_linux_full_ver(os_release, self.dist)
         except:
-            if strict:
+            if self.strict:
                 raise Error("Cannot determine distribution")
             self.os_ver = self.os_full_ver = 'unknown'
 
@@ -224,7 +224,7 @@ class Platform:
 
     def _identify_linux_dist(self, os_release):
         distname = os_release.id()
-        if distname == 'fedora' or  distname == 'debian' or distname == 'arch':
+        if distname == 'fedora' or distname == 'debian':
             pass
         elif distname == 'ubuntu':
             if self.osnick == 'ubuntu14.04':
@@ -238,6 +238,8 @@ class Platform:
         elif distname.startswith('amzn'):
             distname = 'amzn'
             self.osnick = 'amzn' + str(os_release.version_id())
+        elif distname.startswith('arch') or distname.startswith('manjaro'):
+            distname = 'arch'
         else:
             if self.strict:
                 raise Error("Cannot determine distribution")
@@ -309,6 +311,9 @@ class Platform:
 
     def is_redhat_compat(self):
         return self.dist == 'redhat' or self.dist == 'centos' or self.dist == 'amzn'
+
+    def is_arch_compat(self):
+        return self.dist == 'arch'
 
     def is_arm(self):
         return self.arch == 'arm64v8' or self.arch == 'arm32v7'


### PR DESCRIPTION
Added a command-line switch to check if running on arch, explicitly including my derivative, manjaro. While where, I also fixed the check in strict within the platform determination code - it needed to refer to the class-level variable, rather than a local.