### PR TITLE
added arch? check including manjaro call

### DIFF
--- a/bin/getrmpytools
+++ b/bin/getrmpytools
@@ -44,7 +44,7 @@ class RMPyToolsSetup(paella.Setup):
         if not self.psutil_installed:
             self.build_and_install("python%s-devel" % self.pyver)
 
-    def arch_compat(self):
+    def archlinux(self):
         if not self.psutil_installed:
             self.psutil_installed = self.install("python-psutil", _try=True, output=False) == 0
 

--- a/bin/getrmpytools
+++ b/bin/getrmpytools
@@ -44,6 +44,10 @@ class RMPyToolsSetup(paella.Setup):
         if not self.psutil_installed:
             self.build_and_install("python%s-devel" % self.pyver)
 
+    def arch_compat(self):
+        if not self.psutil_installed:
+            self.psutil_installed = self.install("python-psutil", _try=True, output=False) == 0
+
     def fedora(self):
         if not self.psutil_installed:
             self.psutil_installed = self.install("python%s-psutil" % self.pyver, _try=True, output=False) == 0

--- a/bin/platform
+++ b/bin/platform
@@ -21,6 +21,7 @@ parser.add_argument('--arch', action="store_true", help='CPU Architecture')
 
 parser.add_argument('--debian?', action="store_true", help='is Debian-like distribution?')
 parser.add_argument('--redhat?', action="store_true", help='is Redhat-like distribution?')
+parser.add_argument('--arch?', action="store_true", help='is Arch-like distribution?')
 parser.add_argument('--container?', action="store_true", help='running in container?')
 parser.add_argument('--conda?', action="store_true", help='Has Conda installer?') # TODO
 
@@ -49,6 +50,10 @@ if args.__dict__['redhat?']:
 
 if args.__dict__['container?']:
     print(1 if platform.is_container() else 0)
+    sys.exit(0)
+
+if args.__dict__['arch?']:
+    print(1 if platform.is_arch_compat() else 0)
     sys.exit(0)
 
 ret = ""

--- a/paella/platform.py
+++ b/paella/platform.py
@@ -361,8 +361,8 @@ class OnPlatform:
                 if self.platform.is_redhat_compat():
                     self.redhat_compat()
                 if self.platform.is_arch_compat():
-                    if getattr(self, "arch_compat", None) is not None:
-                        self.arch_compat()
+                    if getattr(self, "archlinux", None) is not None:
+                        self.archlinux()
 
                 if dist == 'fedora':
                     self.fedora()

--- a/paella/platform.py
+++ b/paella/platform.py
@@ -238,9 +238,9 @@ class Platform:
         elif distname.startswith('amzn'):
             distname = 'amzn'
             self.osnick = 'amzn' + str(os_release.version_id())
-        elif distname.startswith('arch') or distname.startswith('manjaro'):
-            distname = 'arch'
         else:
+            if os_release.id_like() == 'arch':
+                distname = 'arch'
             if self.strict:
                 raise Error("Cannot determine distribution")
             elif distname == '':

--- a/paella/platform.py
+++ b/paella/platform.py
@@ -70,7 +70,7 @@ class Platform:
     class OSRelease():
         CUSTOM_BRANDS = [ 'elementary', 'pop' ]
         UBUNTU_BRANDS = [ 'elementary', 'pop' ]
-        
+
         def __init__(self, brand=False):
             self.defs = {}
             self.brand_mode = brand
@@ -111,7 +111,7 @@ class Platform:
                 if ver_id == "":
                     raise Error("Cannot determine os version")
                 return ver_id
-                    
+
             ver = self.defs.get("VERSION_ID", "")
             if ver == "" and self.id() == 'debian':
                 ver, _ = self.debian_sid_version()
@@ -123,7 +123,7 @@ class Platform:
                 return DEBIAN_VERSIONS.get(m[1], ""), m[1]
             else:
                 return "", ""
-        
+
         def version_codename(self):
             brand = self.brand_id()
             if brand in self.UBUNTU_BRANDS:
@@ -360,6 +360,9 @@ class OnPlatform:
                     self.debian_compat()
                 if self.platform.is_redhat_compat():
                     self.redhat_compat()
+                if self.platform.is_arch_compat():
+                    if getattr(self, "arch_compat", None) is not None:
+                        self.arch_compat()
 
                 if dist == 'fedora':
                     self.fedora()
@@ -374,7 +377,7 @@ class OnPlatform:
                 elif dist == 'suse':
                     self.suse()
                 elif dist == 'arch':
-                    self.arch()
+                    self.archlinux()
                 elif dist == 'linuxmint':
                     self.linuxmint()
                 elif dist == 'amzn':
@@ -408,7 +411,7 @@ class OnPlatform:
     def linux_last(self):
         pass
 
-    def arch(self):
+    def archlinux(self):
         pass
 
     def debian_compat(self): # debian, ubuntu, etc

--- a/paella/platform.py
+++ b/paella/platform.py
@@ -202,7 +202,7 @@ class Platform:
             self.dist = self._identify_linux_dist(os_release)
             self.os_full_ver = self._identify_linux_full_ver(os_release, self.dist)
         except:
-            if strict:
+            if self.strict:
                 raise Error("Cannot determine distribution")
             self.os_ver = self.os_full_ver = 'unknown'
 
@@ -224,7 +224,7 @@ class Platform:
 
     def _identify_linux_dist(self, os_release):
         distname = os_release.id()
-        if distname == 'fedora' or  distname == 'debian' or distname == 'arch':
+        if distname == 'fedora' or distname == 'debian':
             pass
         elif distname == 'ubuntu':
             if self.osnick == 'ubuntu14.04':
@@ -238,6 +238,8 @@ class Platform:
         elif distname.startswith('amzn'):
             distname = 'amzn'
             self.osnick = 'amzn' + str(os_release.version_id())
+        elif distname.startswith('arch') or distname.startswith('manjaro'):
+            distname = 'arch'
         else:
             if self.strict:
                 raise Error("Cannot determine distribution")
@@ -309,6 +311,9 @@ class Platform:
 
     def is_redhat_compat(self):
         return self.dist == 'redhat' or self.dist == 'centos' or self.dist == 'amzn'
+
+    def is_arch_compat(self):
+        return self.dist == 'arch'
 
     def is_arm(self):
         return self.arch == 'arm64v8' or self.arch == 'arm32v7'

--- a/paella/setup.py
+++ b/paella/setup.py
@@ -221,7 +221,7 @@ class Pacman(PackageManager):
 
     def install(self, packs, group=False, output="on_error", _try=False, aur=False):
         if aur is False:
-            return self.run("sudo pacman --noconfirm -S " + packs, output=output, _try=_try, sudo=True)
+            return self.run("pacman --noconfirm -S " + packs, output=output, _try=_try, sudo=True)
         else:
             if os.path.isfile("/usr/bin/yay"):
                 aurbin = "yay"

--- a/paella/setup.py
+++ b/paella/setup.py
@@ -219,11 +219,20 @@ class Pacman(PackageManager):
     def __init__(self, runner):
         super(Pacman, self).__init__(runner)
 
-    def install(self, packs, group=False, output="on_error", _try=False):
-        return self.run("pacman --noconfirm -S " + packs, output=output, _try=_try, sudo=True)
+    def install(self, packs, group=False, output="on_error", _try=False, aur=False):
+        if aur is False:
+            return self.run("sudo pacman --noconfirm -S " + packs, output=output, _try=_try, sudo=True)
+        else:
+            if os.path.isfile("/usr/bin/yay"):
+                aurbin = "yay"
+            if os.path.isfile("/usr/bin/trizen"):
+                aurbin = "trizen"
+            else:
+                raise FileNotFoundError("Failed to find yay or trizen, for aur package installation.")
+            return self.run("{} --noconfirm -S {}".format(aurbin, packs), output=output, _try=_try, sudo=True)
 
     def uninstall(self, packs, group=False, output="on_error", _try=False):
-        return self.run("pacman --noconfirm -R " + packs, output=output, _try=_try, sudo=True)
+        return self.run("sudo pacman --noconfirm -R " + packs, output=output, _try=_try, sudo=True)
 
     def add_repo(self, repourl, repo="", output="on_error", _try=False):
         return False
@@ -323,8 +332,8 @@ class Setup(OnPlatform):
 
     #------------------------------------------------------------------------------------------
 
-    def install(self, packs, group=False, output="on_error", _try=False):
-        return self.package_manager.install(packs, group=group, output=output, _try=_try)
+    def install(self, packs, group=False, output="on_error", _try=False, **kwargs):
+        return self.package_manager.install(packs, group=group, output=output, _try=_try, **kwargs)
 
     def uninstall(self, packs, group=False, output="on_error", _try=False):
         return self.package_manager.uninstall(packs, group=group, output=output, _try=_try)

--- a/paella/setup.py
+++ b/paella/setup.py
@@ -232,7 +232,7 @@ class Pacman(PackageManager):
             return self.run("{} --noconfirm -S {}".format(aurbin, packs), output=output, _try=_try, sudo=True)
 
     def uninstall(self, packs, group=False, output="on_error", _try=False):
-        return self.run("sudo pacman --noconfirm -R " + packs, output=output, _try=_try, sudo=True)
+        return self.run("pacman --noconfirm -R " + packs, output=output, _try=_try, sudo=True)
 
     def add_repo(self, repourl, repo="", output="on_error", _try=False):
         return False


### PR DESCRIPTION
This starts to add Arch Linux support for modules that support it. By implementing an function called _arch_compat_, Redis modules can add explicit Arch support.