### PR TITLE
docker tag fix on latest with tag

### DIFF
--- a/mk/docker.native
+++ b/mk/docker.native
@@ -137,9 +137,9 @@ endif
 
 # when no version is defined, attempt to use the tag
 # if the tag is defined, and it matches our last
-ifndef ($VERSION)
+ifeq ($(VERSION),)
 TAG_NAME=$(shell git describe --exact-match --tags $$(git log -n1 --pretty='%h')|cut -d 'v' -f 2-2)
-ifneq ($TAG_NAME,)
+ifneq ($(TAG_NAME),)
 BASE_TAG=$(shell echo $(TAG_NAME) | cut -d '.' -f 1-2)
 ifeq ($(BASE_TAG),$(LATEST_BRANCH))
 D_VERSION=$(TAG_NAME)

--- a/mk/docker.native
+++ b/mk/docker.native
@@ -135,6 +135,19 @@ ifeq ($(BRANCH),master)
 PUSH_EDGE=1
 endif
 
+# when no version is defined, attempt to use the tag
+# if the tag is defined, and it matches our last
+ifndef ($VERSION)
+TAG_NAME=$(shell git describe --exact-match --tags $$(git log -n1 --pretty='%h')|cut -d 'v' -f 2-2)
+ifneq (TAG_NAME,)
+BASE_TAG=$(shell echo $(TAG_NAME) | cut -d '.' -f 1-2)
+ifeq ($(BASE_TAG), $(LATEST_BRANCH))
+D_VERSION=$(TAG_NAME)
+PUSH_LATEST=1
+endif
+endif
+endif
+
 endif # OFFICIAL
 
 ifeq ($(VERBOSE),1)
@@ -149,6 +162,7 @@ $(info OFFICIAL=$(OFFICIAL))
 $(info PUSH_GENERAL=$(PUSH_GENERAL))
 $(info PUSH_EDGE=$(PUSH_EDGE))
 $(info PUSH_LATEST=$(PUSH_LATEST))
+$(info TAG_NAME=$(TAG_NAME))
 endif
 
 #----------------------------------------------------------------------------------------------

--- a/mk/docker.native
+++ b/mk/docker.native
@@ -139,9 +139,9 @@ endif
 # if the tag is defined, and it matches our last
 ifndef ($VERSION)
 TAG_NAME=$(shell git describe --exact-match --tags $$(git log -n1 --pretty='%h')|cut -d 'v' -f 2-2)
-ifneq (TAG_NAME,)
+ifneq ($TAG_NAME,)
 BASE_TAG=$(shell echo $(TAG_NAME) | cut -d '.' -f 1-2)
-ifeq ($(BASE_TAG), $(LATEST_BRANCH))
+ifeq ($(BASE_TAG),$(LATEST_BRANCH))
 D_VERSION=$(TAG_NAME)
 PUSH_LATEST=1
 endif


### PR DESCRIPTION
Automatically set the docker tag on latest, as desired. Attached is a log of the run in both cases.

[sample-build-run.log](https://github.com/RedisLabsModules/readies/files/6228401/sample-build-run.log)
