### PR TITLE
gcc9 for newer ubuntus when not modern

### DIFF
--- a/bin/getgcc
+++ b/bin/getgcc
@@ -35,6 +35,14 @@ class SystemSetup(paella.Setup):
             self.run("apt-get update -qq")
             self.run("apt-get install -y -t testing build-essential")
 
+        #  we cannot use gcc10 in many contexts - this change allows compilation on new ubuntus, and
+        # gcc10 (for now)
+        if self.modern is False and self.osnick in ['hirsute', 'focal']:
+            self.install("gcc-9 g++-9")
+            self.run("update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9")
+            self.run("update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9")
+
+
     def redhat_compat(self):
         self.group_install("'Development Tools'")
         if self.modern:


### PR DESCRIPTION
Newer ubuntus receive gcc10 when getgcc is run (hirsute+). But, gcc-9 packages are available, and necessary for some products. This PR pulls down for specific ubuntus gcc-9 when modern isn't set. This makes it possible to build on 20.04 and 21.04.