### PR TITLE
platform arch is arm64v8 on m1, but returns as arm64

### DIFF
--- a/paella/platform.py
+++ b/paella/platform.py
@@ -304,6 +304,8 @@ class Platform:
             self.arch = 'arm64v8'
         elif self.arch == 'armv7l':
             self.arch = 'arm32v7'
+        elif self.arch == 'arm64' and self.os == 'macos':
+            self.arch = 'arm64v8'
 
     #------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
we do not know what the m2 will do, so this is defensive for now