### PR TITLE
bump clang version from 10 to 11 for arm build of official rejson

### DIFF
--- a/bin/getclang
+++ b/bin/getclang
@@ -59,7 +59,7 @@ class CLangSetup(paella.Setup):
 
         if self.osnick != "trusty":
             if self.platform.is_arm():
-                clang_ver = "10"
+                clang_ver = "11"
             elif self.osnick in ["xenial", "stretch", "buster", "bionic"]:
                 clang_ver = "12"
             else:


### PR DESCRIPTION
I have been trying to build RedisJSON for arm64. It failed when trying install `llvm-toolchain-bullseye-10` on debian bullseye, as it looks like that has been updated to 11.