### PR TITLE
python validation across debians, ubuntus, centos7/8

### DIFF
--- a/bin/getpy3
+++ b/bin/getpy3
@@ -173,7 +173,7 @@ install_pip() {
 		export DEBIAN_FRONTEND=noninteractive
 		runn $SUDO apt-get -qq update
 		runn $SUDO apt-get install -y $packs
-        runn $SUDO apt-get install -y python3-distutils || runn $SUDO apt-get install -y  python3-distutils-extra
+		runn $SUDO apt-get install -y python3-distutils || runn $SUDO apt-get install -y  python3-distutils-extra
 	elif is_command dnf; then
 		runn $SUDO dnf install -y $packs
 	elif is_command yum; then

--- a/bin/getpy3
+++ b/bin/getpy3
@@ -161,10 +161,7 @@ install_python() {
 }
 
 install_pip() {
-	if [[ $FORCE != 1 ]]; then
-		[[ $($MYPY -m pip --version > /dev/null 2>&1; echo $?) == 0 ]] && return
-	fi
-
+    set -x
 	pipspec=""
 	[[ $PIP != 1 ]] && pipspec="pip==$PIP"
 
@@ -174,9 +171,7 @@ install_pip() {
 		export DEBIAN_FRONTEND=noninteractive
 		runn $SUDO apt-get -qq update
 		runn $SUDO apt-get install -y $packs
-		# if [[ -n $(apt-cache search --names-only '^python3-distutils$')  ]]; then
-		# 	runn $SUDO apt-get install -y python3-distutils
-		# fi
+        runn $SUDO apt-get install -y python3-distutils || runn $SUDO apt-get install -y  python3-distutils-extra
 	elif is_command dnf; then
 		runn $SUDO dnf install -y $packs
 	elif is_command yum; then
@@ -195,21 +190,18 @@ install_pip() {
 		runn $SUDO pacman -Syy --noconfirm $packs
 	fi
 
-	runn wget -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py
+    $MYPY -c 'import sys;  print(f"{sys.version_info.major}.{sys.version_info.minor}")'|grep '3.6' &>/dev/null
+	if [ $? -eq 0 ]; then
+		pypi_url=' https://bootstrap.pypa.io/pip/3.6/get-pip.py'
+	else
+		pypi_url='https://bootstrap.pypa.io/get-pip.py'
+	fi
+	runn wget -O /tmp/get-pip.py ${pypi_url}
 	# currently can fail on debian-compat platforms due to distutils:
 	# `python3 -m pip --version` will fail to find pip
 	runn "$MYPY /tmp/get-pip.py $pipspec || true"
 	rm -f /tmp/get-pip.py
-	if [[ $PIP == 19.3.1 ]]; then
-		runn $MYPY -m pip install setuptools==49.3.0
-	fi
-	# workaround for pip installation problem
-	if ! $MYPY -m pip --version &> /dev/null; then
-		if is_command apt-get; then
-			runn $SUDO apt-get install -y python3-pip
-			runn $MYPY -m pip install --upgrade pip
-		fi
-	fi
+    $MYPY -m pip install --upgrade pip
 }
 
 check_variants

--- a/bin/getpy3
+++ b/bin/getpy3
@@ -161,7 +161,9 @@ install_python() {
 }
 
 install_pip() {
-    set -x
+	if [[ $FORCE != 1 ]]; then
+		[[ $($MYPY -m pip --version > /dev/null 2>&1; echo $?) == 0 ]] && return
+	fi
 	pipspec=""
 	[[ $PIP != 1 ]] && pipspec="pip==$PIP"
 

--- a/bin/getpy3
+++ b/bin/getpy3
@@ -192,7 +192,7 @@ install_pip() {
 		runn $SUDO pacman -Syy --noconfirm $packs
 	fi
 
-    $MYPY -c 'import sys;  print(f"{sys.version_info.major}.{sys.version_info.minor}")'|grep '3.6' &>/dev/null
+	$MYPY -c 'import sys;  print(f"{sys.version_info.major}.{sys.version_info.minor}")'|grep '3.6' &>/dev/null
 	if [ $? -eq 0 ]; then
 		pypi_url=' https://bootstrap.pypa.io/pip/3.6/get-pip.py'
 	else
@@ -203,7 +203,7 @@ install_pip() {
 	# `python3 -m pip --version` will fail to find pip
 	runn "$MYPY /tmp/get-pip.py $pipspec || true"
 	rm -f /tmp/get-pip.py
-    $MYPY -m pip install --upgrade pip
+	$MYPY -m pip install --upgrade pip
 }
 
 check_variants


### PR DESCRIPTION
untested on osx, validated on stock:
ubuntu xenial
ubuntu bionic
ubuntu focal
centos 7
centos 8
bullseye
buster
select random OSes.
