### PR TITLE
paella/platform.py: fixed the rasbian os detection

### DIFF
--- a/paella/platform.py
+++ b/paella/platform.py
@@ -355,7 +355,7 @@ class Platform:
     #------------------------------------------------------------------------------------------
 
     def is_debian_compat(self):
-        return self.dist in ['debian', 'ubuntu', 'linuxmint', 'rasbpian']
+        return self.dist in ['debian', 'ubuntu', 'linuxmint', 'raspbian']
 
     def is_redhat_compat(self):
         return self.dist in ['redhat', 'centos', 'amzn', 'ol']


### PR DESCRIPTION
The raspbian string was wrongly spelled

Signed-off-by: Thierry Bultel <thierry.bultel@linatsea.fr>