### PR TITLE
Linux Amazon2: getredis - Install openssl11-devel

### DIFF
--- a/bin/getredis
+++ b/bin/getredis
@@ -460,7 +460,12 @@ index b0727db2c..ae7f3f80a 100644
         if self.no_prepare:
             return
         self.group_install("'Development Tools'")
-        self.install("openssl-devel")
+
+        if self.osnick == 'amzn2':
+            self.uninstall("openssl-devel")
+            self.install("openssl11-devel")
+        else:
+            self.install("openssl-devel")
 
     def fedora(self):
         if self.no_prepare:


### PR DESCRIPTION
In Linux Amazon 2, `getredis` should install the package `openssl11-devel` because it is required by RedisJsonHdt tests.
