### PR TITLE
fix cmake build from sources

### DIFF
--- a/bin/getcmake
+++ b/bin/getcmake
@@ -124,9 +124,9 @@ class CMakeSetup(paella.Setup):
                 make -j`nproc`
                 """.format(DIR=dir, CMAKE_VER=CMAKE_VER))
             self.run(r"""
-                make -C {DIR} install
+                make -C {DIR}/CMake-{CMAKE_VER} install
                 rm -rf {DIR}
-                """.format(DIR=dir), sudo=True)
+                """.format(DIR=dir, CMAKE_VER=CMAKE_VER), sudo=True)
 
 #----------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
on debian:bullseye-slim docker, `make install` is not executed in the right directory:
```
cd /tmp/cmake.0eufzq3_; wget -q -O cmake.zip https://github.com/Kitware/CMake/archive/v3.22.2.zip; unzip -q cmake.zip; cd CMake-3.22.2/; ./bootstrap --parallel=`nproc`; make -j`nproc`
make -C /tmp/cmake.0eufzq3_ install; rm -rf /tmp/cmake.0eufzq3_
make: Entering directory '/tmp/cmake.0eufzq3_'
make: *** No rule to make target 'install'.  Stop.
make: Leaving directory '/tmp/cmake.0eufzq3_'
```