### PR TITLE
MOD-6341 Fix arch comparison in getepel

### DIFF
--- a/bin/getepel
+++ b/bin/getepel
@@ -49,7 +49,7 @@ READIES=$(cd $HERE/.. && pwd)
 
 install_raven() {
 	# enable raven repo (i.e. pkgs.org)
-	if (( EPEL < 8 || arch != x86_64 || NO_RAVEN == 1 )); then
+	if (( EPEL < 8 )) || [[ $arch != x86_64 ]] || (( NO_RAVEN == 1 )); then
 		return
 	fi
 


### PR DESCRIPTION
This patch is to fix an error that prevents the generation of docker image for arm8-rocky8 and arm-rocky9
install_raven(): Fix architecture comparison.
