### PR TITLE
Print LLVM and Rust Coverage Errors

### DIFF
--- a/mk/coverage.defs
+++ b/mk/coverage.defs
@@ -53,17 +53,17 @@ endef
 define COVERAGE_COLLECT.llvm
 $(SHOW)set -e ;\
 echo "Collecting coverage data ..." ;\
-llvm-profdata merge --sparse `ls $(COV_DIR)/*.profraw` -o $(COV_PROFDATA) &> /dev/null ;\
+llvm-profdata merge --sparse `ls $(COV_DIR)/*.profraw` -o $(COV_PROFDATA) ;\
 llvm-cov export --format=lcov --instr-profile $(COV_PROFDATA) $(TARGET) > $(COV_INFO).all ;\
-lcov -o $(COV_INFO) -r $(COV_INFO).all $(COV_EXCLUDE.llvm) &> /dev/null
+lcov -o $(COV_INFO) -r $(COV_INFO).all $(COV_EXCLUDE.llvm)
 endef
 
 define COVERAGE_COLLECT.rust
 $(SHOW)set -e ;\
 echo "Collecting coverage data ..." ;\
-llvm-profdata merge --sparse `ls $(COV_DIR)/*.profraw` -o $(COV_PROFDATA) &> /dev/null ;\
+llvm-profdata merge --sparse `ls $(COV_DIR)/*.profraw` -o $(COV_PROFDATA) ;\
 llvm-cov export --format=lcov --instr-profile $(COV_PROFDATA) $(TARGET) > $(COV_INFO).all ;\
-lcov -o $(COV_INFO) -r $(COV_INFO).all $(COV_EXCLUDE.llvm) &> /dev/null
+lcov -o $(COV_INFO) -r $(COV_INFO).all $(COV_EXCLUDE.llvm)
 endef
 
 #----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Would like to see coverage errors if coverage fails for some reason.
Right now we have no idea the reason for the failure.