### PR TITLE
Remove unsetting of the NDEBUG build flag

### DIFF
--- a/mk/cc.defs
+++ b/mk/cc.defs
@@ -241,7 +241,6 @@ LD_LIBS += \
 #---------------------------------------------------------------------------------------- CMake
 
 export CMAKE_CC_FLAGS=\
-	-UNDEBUG \
 	$(CC_FLAGS.core)
 
 export CMAKE_CC_C_FLAGS=$(CC_C_FLAGS)


### PR DESCRIPTION
Removes the unsetting of the `NDEBUG` flag that was unset always, as we rely on this flag in our code-base (RediSearch).